### PR TITLE
Add Macro & Variable

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,9 @@ seeds:
         name: varchar
         discount_percent: numeric(18,2)
 
+vars:
+  default_date: '9999-01-01'
+
 models:
   dbt_training:
     staging:

--- a/models/staging/tech_store/stg_tech_store__employees.sql
+++ b/models/staging/tech_store/stg_tech_store__employees.sql
@@ -14,7 +14,7 @@ final as (
         lname as last_name,
         concat(first_name, ' ', last_name) as full_name,
         hiredate as hired_at,
-        enddate as terminated_at,
+        nvl(enddate, '{{var("default_date")}}') as terminated_at,
         iff(terminated_at is null, true, false) as is_active 
     from employees
 


### PR DESCRIPTION
### Summary
Add custom `macro` & default `variable`

### Details
Added a new `macro`
* `utc_to_est` - Converts a UTC timestamp value to an Eastern Timezone value

Added a new `variable`
* `default_date` - Provides a default date for missing/null values ('9999-01-01')

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Macros](https://docs.getdbt.com/docs/building-a-dbt-project/jinja-macros)
[Variables](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-variables)