### PR TITLE
Deploy to Production

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,6 +18,7 @@ clean-targets:
 
 seeds:
   dbt_training:
+    +schema: staging
     sale_dates:
       +column_types:
         sale_date: date
@@ -31,9 +32,11 @@ models:
   dbt_training:
     staging:
       +materialized: view
+      +schema: staging
     intermediate:
       +materialized: ephemeral
     marts:
       +materialized: table
+      +schema: marts
       +tags:
         - p1

--- a/macros/generate_custom_schema.sql
+++ b/macros/generate_custom_schema.sql
@@ -1,0 +1,14 @@
+{% macro temp_generate_schema_name(custom_schema_name, node) -%}
+
+    {%- set default_schema = target.schema -%}
+    {%- if target.name == 'prod' -%}
+
+        {{ custom_schema_name | trim }}
+
+    {%- else -%}
+
+        {{ default_schema }}
+
+    {%- endif -%}
+
+{%- endmacro %}

--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}


### PR DESCRIPTION
### Summary
Deploy current project to Production

### Details
Add `prod` target to `sample-profiles.yml`
`get_custom_schema.sql` - Uses the built-in macros `generate_schema_name` and `generate_schema_name_for_env`
   * Will result in all models being deployed to a `target` schema in non-prod environments (ex. `dev`, `qa`)
   * If `target` =  `prod` all models will be deployed to the individual custom schemas (ex. `staging`, `mart`)

Confirmed ability to deploy to `prod`.

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Target](https://docs.getdbt.com/reference/dbt-jinja-functions/target)
[Using Custom Schemas](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas)

